### PR TITLE
New wpi sim

### DIFF
--- a/simgui-ds.json
+++ b/simgui-ds.json
@@ -1,10 +1,17 @@
 {
+  "Keyboard 0 Settings": {
+    "window": {
+      "visible": true
+    }
+  },
   "keyboardJoysticks": [
     {
       "axisConfig": [
         {
           "decKey": 81,
-          "incKey": 69
+          "decayRate": 1.0,
+          "incKey": 69,
+          "keyRate": 1.0
         },
         {},
         {
@@ -14,12 +21,16 @@
         },
         {},
         {
-          "decKey": 65,
-          "incKey": 68
+          "decKey": 87,
+          "decayRate": 1.0,
+          "incKey": 83,
+          "keyRate": 1.0
         },
         {
-          "decKey": 83,
-          "incKey": 87
+          "decKey": 68,
+          "decayRate": 1.0,
+          "incKey": 65,
+          "keyRate": 1.0
         }
       ],
       "axisCount": 6,

--- a/simgui.json
+++ b/simgui.json
@@ -41,6 +41,9 @@
         "name": "Rear Left Steer"
       },
       "navX-Sensor[4]": {
+        "header": {
+          "open": true
+        },
         "name": "navX"
       }
     },

--- a/simgui.json
+++ b/simgui.json
@@ -55,7 +55,16 @@
       "/FMSInfo": "FMSInfo",
       "/LiveWindow/Ungrouped/Scheduler": "Scheduler",
       "/LiveWindow/Ungrouped/frc2::SubsystemBase": "Subsystem",
-      "/LiveWindow/Ungrouped/navX-Sensor[4]": "Gyro"
+      "/LiveWindow/Ungrouped/navX-Sensor[4]": "Gyro",
+      "/SmartDashboard/Field": "Field2d",
+      "/SmartDashboard/Reset Encoders": "Command"
+    },
+    "windows": {
+      "/SmartDashboard/Field": {
+        "window": {
+          "visible": true
+        }
+      }
     }
   },
   "NetworkTables": {
@@ -64,6 +73,15 @@
         "open": true
       },
       "SmartDashboard": {
+        "Sim": {
+          "Modules": {
+            "Front Left": {
+              "open": true
+            },
+            "open": true
+          },
+          "open": true
+        },
         "open": true
       }
     }

--- a/src/main/cpp/commands/DriveTrajectory.cpp
+++ b/src/main/cpp/commands/DriveTrajectory.cpp
@@ -6,7 +6,6 @@
 #include <units/angular_velocity.h>
 #include <units/velocity.h>
 
-using namespace frc;
 using namespace units;
 
 DriveTrajectory::DriveTrajectory(SwerveDrive* drive, const Trajectory* trajectory)
@@ -44,7 +43,7 @@ void DriveTrajectory::Execute() {
   m_ySetpointLog.Append(state.pose.Y().value());
   m_thetaSetpointLog.Append(state.pose.Rotation().Radians().value());
 
-  m_drive->Drive(ChassisSpeeds::FromFieldRelativeSpeeds(
+  m_drive->Drive(frc::ChassisSpeeds::FromFieldRelativeSpeeds(
       vx, vy, omega, m_drive->GetPose().Rotation()));
 }
 

--- a/src/main/cpp/subsystems/SwerveDrive.cpp
+++ b/src/main/cpp/subsystems/SwerveDrive.cpp
@@ -7,10 +7,12 @@
 #include <frc/Timer.h>
 #include <frc/geometry/Pose2d.h>
 #include <frc/geometry/Rotation2d.h>
+#include <frc/geometry/Twist2d.h>
 #include <frc/geometry/Translation2d.h>
 #include <frc/kinematics/SwerveDriveKinematics.h>
 #include <frc/kinematics/SwerveDriveOdometry.h>
 #include <frc/kinematics/SwerveModuleState.h>
+#include <frc/kinematics/SwerveModulePosition.h>
 #include <photonlib/PhotonCamera.h>
 #include <units/angle.h>
 #include <units/base.h>
@@ -18,11 +20,18 @@
 #include <units/length.h>
 #include <frc2/command/InstantCommand.h>
 #include <frc/smartdashboard/SmartDashboard.h>
+#include "Constants.h"
+#include <Eigen/src/Core/Matrix.h>
+#include <frc/RobotBase.h>
+#include <units/angular_velocity.h>
+#include <units/velocity.h>
 #include "util/log/DoubleTelemetryEntry.h"
+#include <wpi/array.h>
 
 #include <frc/kinematics/SwerveModulePosition.h>
 #include "subsystems/Vision.h"
 #include "util/log/TelemetryEntry.h"
+#include "wpi/array.h"
 
 #include <frc/smartdashboard/Field2d.h>
 
@@ -66,8 +75,13 @@ SwerveDrive::SwerveDrive()
       m_poseEstimateThetaLog("Drive/Pose Estimate/Theta", TelemetryLevel::kCompetition),
       m_visionPoseEstimateXLog("Vision/Pose Estimate/X", TelemetryLevel::kCompetition),
       m_visionPoseEstimateYLog("Vision/Pose Estimate/Y", TelemetryLevel::kCompetition),
-      m_visionPoseEstimateThetaLog("Vision/Pose Estimate/Theta", TelemetryLevel::kCompetition) {
+      m_visionPoseEstimateThetaLog("Vision/Pose Estimate/Theta", TelemetryLevel::kCompetition),
+      m_gyroSim("navX-Sensor", 4),
+      m_gyroSimYaw(m_gyroSim.GetDouble("Yaw")) {
   SmartDashboard::PutData("Field", &m_field);
+  if constexpr (RobotBase::IsSimulation()) {
+    // m_simTimer.Start();
+  }
 }
 
 Pose2d SwerveDrive::GetPose() const {
@@ -163,6 +177,26 @@ void SwerveDrive::Periodic() {
   m_poseEstimateThetaLog.Append(m_poseEstimator.GetEstimatedPosition().Rotation().Radians().value());
 
   m_field.SetRobotPose(m_poseEstimator.GetEstimatedPosition());
+}
+
+void SwerveDrive::SimulationPeriodic() {
+  // units::second_t dt = m_simTimer.Get();
+  // m_simTimer.Reset();
+
+  wpi::array<SwerveModulePosition, 4> moduleDeltas(wpi::empty_array);
+  for (size_t index = 0; index < 4; index++) {
+    auto& lastPosition = m_previousModulePositions[index];
+    auto currentPosition = m_modules[index].GetPosition();
+    moduleDeltas[index] = {currentPosition.distance - lastPosition.distance,
+                           currentPosition.angle};
+
+    m_previousModulePositions[index].distance = m_modules[index].GetPosition().distance;
+  }
+
+  Twist2d delta = m_driveKinematics.ToTwist2d(moduleDeltas);
+
+  degree_t convertedDelta = -delta.dtheta;
+  m_gyroSimYaw.Set(m_gyroSimYaw.Get() + convertedDelta.value());
 }
 
 void SwerveDrive::ResetAbsoluteEncoders() {

--- a/src/main/cpp/subsystems/SwerveDrive.cpp
+++ b/src/main/cpp/subsystems/SwerveDrive.cpp
@@ -17,11 +17,14 @@
 #include <units/time.h>
 #include <units/length.h>
 #include <frc2/command/InstantCommand.h>
+#include <frc/smartdashboard/SmartDashboard.h>
 #include "util/log/DoubleTelemetryEntry.h"
 
 #include <frc/kinematics/SwerveModulePosition.h>
 #include "subsystems/Vision.h"
 #include "util/log/TelemetryEntry.h"
+
+#include <frc/smartdashboard/Field2d.h>
 
 using namespace frc;
 using namespace frc2;
@@ -64,6 +67,7 @@ SwerveDrive::SwerveDrive()
       m_visionPoseEstimateXLog("Vision/Pose Estimate/X", TelemetryLevel::kCompetition),
       m_visionPoseEstimateYLog("Vision/Pose Estimate/Y", TelemetryLevel::kCompetition),
       m_visionPoseEstimateThetaLog("Vision/Pose Estimate/Theta", TelemetryLevel::kCompetition) {
+  SmartDashboard::PutData("Field", &m_field);
 }
 
 Pose2d SwerveDrive::GetPose() const {
@@ -157,6 +161,8 @@ void SwerveDrive::Periodic() {
   m_poseEstimateXLog.Append(m_poseEstimator.GetEstimatedPosition().X().value());
   m_poseEstimateYLog.Append(m_poseEstimator.GetEstimatedPosition().Y().value());
   m_poseEstimateThetaLog.Append(m_poseEstimator.GetEstimatedPosition().Rotation().Radians().value());
+
+  m_field.SetRobotPose(m_poseEstimator.GetEstimatedPosition());
 }
 
 void SwerveDrive::ResetAbsoluteEncoders() {

--- a/src/main/cpp/subsystems/SwerveModule.cpp
+++ b/src/main/cpp/subsystems/SwerveModule.cpp
@@ -92,6 +92,10 @@ SwerveModule::SwerveModule(int driveMotorID, int steerMotorID, int absEncoderID)
 
   m_driveMotor.EnableVoltageCompensation(12.0);
   m_driveMotor.EnableVoltageCompensation(12.0);
+
+  if constexpr (RobotBase::IsSimulation()) {
+    m_simTimer.Start();
+  }
 }
 
 frc::SwerveModuleState SwerveModule::GetState() const {
@@ -128,7 +132,6 @@ void SwerveModule::SetDesiredState(
                                  CANSparkMax::ControlType::kVelocity);
   
   if constexpr (RobotBase::IsSimulation()) {
-    m_simTimer.Start();
     m_steerSimPosition.Set(adjustedAngle);
   }
 }

--- a/src/main/cpp/subsystems/SwerveModule.cpp
+++ b/src/main/cpp/subsystems/SwerveModule.cpp
@@ -20,10 +20,9 @@
 #include <frc/simulation/SimDeviceSim.h>
 
 #include "Constants.h"
-#include "frc/DataLogManager.h"
+#include <frc/DataLogManager.h>
 #include <units/time.h>
 #include <frc/RobotBase.h>
-#include <frc/smartdashboard/SmartDashboard.h> // remove
 #include "util/log/TelemetryEntry.h"
 
 using namespace frc;
@@ -144,9 +143,6 @@ void SwerveModule::SimulationPeriodic() {
   units::second_t dt = m_simTimer.Get();
   m_simTimer.Reset();
   m_driveSimPosition.Set(m_driveSimPosition.Get() + m_driveSimVelocity.Get() * dt.value());
-  SmartDashboard::PutNumber("Sim/Modules/" + m_name + "/dt", dt.value());
-  SmartDashboard::PutNumber("Sim/Modules/" + m_name + "/Drive Velocity", m_driveSimVelocity.Get());
-  SmartDashboard::PutNumber("Sim/Modules/" + m_name + "/Drive Position", m_driveSimPosition.Get());
 }
 
 void SwerveModule::ResetEncoders() {

--- a/src/main/include/subsystems/SwerveDrive.h
+++ b/src/main/include/subsystems/SwerveDrive.h
@@ -19,7 +19,10 @@
 #include <photonlib/PhotonCamera.h>
 #include <units/angle.h>
 #include <frc/smartdashboard/Field2d.h>
+#include <frc/simulation/SimDeviceSim.h>
+#include <frc/Timer.h>
 #include "util/log/DoubleTelemetryEntry.h"
+#include <frc/kinematics/SwerveModulePosition.h>
 
 #include "subsystems/SwerveModule.h"
 #include "subsystems/Vision.h"
@@ -54,6 +57,8 @@ class SwerveDrive : public frc2::SubsystemBase {
    * gyro, vision, and encoder sensor data.
    */
   void Periodic() override;
+
+  void SimulationPeriodic() override;
 
   void ResetAbsoluteEncoders();
 
@@ -94,4 +99,13 @@ class SwerveDrive : public frc2::SubsystemBase {
   DoubleTelemetryEntry m_visionPoseEstimateThetaLog;
 
   frc::Field2d m_field;
+
+  // Simulation
+  // frc::Timer m_simTimer;
+
+  frc::sim::SimDeviceSim m_gyroSim;
+  hal::SimDouble m_gyroSimYaw;
+
+  std::array<frc::SwerveModulePosition, 4> m_previousModulePositions{};
+
 };

--- a/src/main/include/subsystems/SwerveDrive.h
+++ b/src/main/include/subsystems/SwerveDrive.h
@@ -18,6 +18,7 @@
 #include <frc2/command/SubsystemBase.h>
 #include <photonlib/PhotonCamera.h>
 #include <units/angle.h>
+#include <frc/smartdashboard/Field2d.h>
 #include "util/log/DoubleTelemetryEntry.h"
 
 #include "subsystems/SwerveModule.h"
@@ -91,4 +92,6 @@ class SwerveDrive : public frc2::SubsystemBase {
   DoubleTelemetryEntry m_visionPoseEstimateXLog;
   DoubleTelemetryEntry m_visionPoseEstimateYLog;
   DoubleTelemetryEntry m_visionPoseEstimateThetaLog;
+
+  frc::Field2d m_field;
 };

--- a/src/main/include/subsystems/SwerveModule.h
+++ b/src/main/include/subsystems/SwerveModule.h
@@ -12,7 +12,10 @@
 #include <rev/CANSparkMaxLowLevel.h>
 #include <rev/RelativeEncoder.h>
 #include <rev/SparkMaxPIDController.h>
+#include <frc/Timer.h>
 #include "util/log/DoubleTelemetryEntry.h"
+
+#include <frc/simulation/SimDeviceSim.h>
 
 class SwerveModule : public frc2::SubsystemBase {
  public:
@@ -25,6 +28,8 @@ class SwerveModule : public frc2::SubsystemBase {
   void SetDesiredState(const frc::SwerveModuleState& state);
 
   void Periodic() override;
+
+  void SimulationPeriodic() override;
 
   void ResetEncoders();
 
@@ -47,4 +52,14 @@ class SwerveModule : public frc2::SubsystemBase {
   DoubleTelemetryEntry m_steerPositionLog;
   DoubleTelemetryEntry m_driveVelocitySetpointLog;
   DoubleTelemetryEntry m_steerPositionSetpointLog;
+
+  // Simulation
+  frc::Timer m_simTimer;
+
+  frc::sim::SimDeviceSim m_driveSim;
+  frc::sim::SimDeviceSim m_steerSim;
+
+  hal::SimDouble m_driveSimVelocity;
+  hal::SimDouble m_driveSimPosition;
+  hal::SimDouble m_steerSimPosition;
 };


### PR DESCRIPTION
* Adds simulation support for the swerve drivetrain (kinematics only)
* Fully integrated with vendordeps using the `SimDeviceSim` class
* Requires a bit of code to make the encoders match the commanded velocities, but much better than making an entire custom HAL