### PR TITLE
Voltage Compensation for Steer Motor, Drivetrain Smart Current Limits

### DIFF
--- a/src/main/cpp/subsystems/SwerveModule.cpp
+++ b/src/main/cpp/subsystems/SwerveModule.cpp
@@ -18,6 +18,7 @@
 #include <rev/RelativeEncoder.h>
 #include <rev/SparkMaxPIDController.h>
 #include <units/time.h>
+#include <units/current.h>
 #include <wpi/DataLog.h>
 
 #include "Constants.hpp"
@@ -91,7 +92,10 @@ SwerveModule::SwerveModule(int driveMotorID, int steerMotorID, int absEncoderID)
                              180);  // convert to rad
 
   m_driveMotor.EnableVoltageCompensation(12.0);
-  m_driveMotor.EnableVoltageCompensation(12.0);
+  m_steerMotor.EnableVoltageCompensation(12.0);
+
+  m_driveMotor.SetSmartCurrentLimit(80);
+  m_steerMotor.SetSmartCurrentLimit(80);
 
   if constexpr (RobotBase::IsSimulation()) {
     m_simTimer.Start();

--- a/src/main/cpp/subsystems/SwerveModule.cpp
+++ b/src/main/cpp/subsystems/SwerveModule.cpp
@@ -18,7 +18,6 @@
 #include <rev/RelativeEncoder.h>
 #include <rev/SparkMaxPIDController.h>
 #include <units/time.h>
-#include <units/current.h>
 #include <wpi/DataLog.h>
 
 #include "Constants.hpp"


### PR DESCRIPTION
- Fixed issue where voltage compensation was not used for steer motor
- Added smart current limits of 80 amps for drive and steer motors