### PR TITLE
Support additional installed LEDs

### DIFF
--- a/src/main/include/Constants.hpp
+++ b/src/main/include/Constants.hpp
@@ -45,8 +45,9 @@ constexpr std::array<int, 8> kAutoSwitchPorts = {11, 12, 13, 18,
 constexpr int kRedBlueSwitchPort = 10;
 
 /// LED strip
-constexpr int kLEDBuffLength = 88;
-constexpr int kLEDStripLength = kLEDBuffLength / 4;
+constexpr int kLEDStripLength = 22;
+constexpr int kAltLEDStripLength = 18;
+constexpr int kLEDBuffLength = kLEDStripLength * 4 + kAltLEDStripLength * 4;
 constexpr bool kStripDirections[] = {false, true, true,
                                      true};  // false means up, true means down
 

--- a/src/main/include/Constants.hpp
+++ b/src/main/include/Constants.hpp
@@ -47,7 +47,7 @@ constexpr int kRedBlueSwitchPort = 10;
 /// LED strip
 constexpr int kLEDStripLength = 22;
 constexpr int kAltLEDStripLength = 18;
-constexpr int kLEDBuffLength = kLEDStripLength * 4 + kAltLEDStripLength * 4;
+constexpr int kLEDBuffLength = kLEDStripLength * 4 + kAltLEDStripLength;
 constexpr bool kStripDirections[] = {false, true, true,
                                      true};  // false means up, true means down
 


### PR DESCRIPTION
We added four more addressable LED strips wired in parallel at the end of the final main strip.

Here is a diagram of the wiring. The original LED strips are denoted `Strip1`, `Strip2`, `Strip3`, and `Strip4` while the new strips are denoted `Strip5`, `Strip6`, `Strip7`, and `Strip8`

```mermaid
graph TD;
    Strip1-->Strip2;
    Strip2-->Strip3;
    Strip3-->Strip4;
    Strip4-->Strip5;
    Strip4-->Strip6;
    Strip4-->Strip7;
    Strip4-->Strip8;
```