### PR TITLE
Use a const map in TrajectoryManager

### DIFF
--- a/src/main/cpp/commands/autos/Mid1ConeChgstat.cpp
+++ b/src/main/cpp/commands/autos/Mid1ConeChgstat.cpp
@@ -33,8 +33,8 @@ Mid1ConeChgstat::Mid1ConeChgstat(SwerveDrive* drive,
       frc2::ParallelDeadlineGroup(
           DriveTrajectory(
               drive,
-              &TrajectoryManager::GetTrajectory(
-                  allianceSidePrefix + "mid-1cone-chgstat_1_chgstat"),
+              &TrajectoryManager::GetTrajectory(allianceSidePrefix +
+                                                "mid-1cone-chgstat_1_chgstat"),
               false),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.5_s),
                                        frc2::InstantCommand([superstructure]() {

--- a/src/main/cpp/commands/autos/Mid1ConeChgstat.cpp
+++ b/src/main/cpp/commands/autos/Mid1ConeChgstat.cpp
@@ -25,7 +25,7 @@ Mid1ConeChgstat::Mid1ConeChgstat(SwerveDrive* drive,
           [superstructure]() { superstructure->PositionHigh(); }),
       frc2::WaitCommand(1.25_s),
       DriveTrajectory(drive,
-                      &TrajectoryManager::GetInstance().GetTrajectory(
+                      &TrajectoryManager::GetTrajectory(
                           allianceSidePrefix + "mid-1cone-chgstat_0_place6")),
       frc2::InstantCommand(
           [superstructure]() { superstructure->SetExtenderPosition(false); }),
@@ -33,7 +33,7 @@ Mid1ConeChgstat::Mid1ConeChgstat(SwerveDrive* drive,
       frc2::ParallelDeadlineGroup(
           DriveTrajectory(
               drive,
-              &TrajectoryManager::GetInstance().GetTrajectory(
+              &TrajectoryManager::GetTrajectory(
                   allianceSidePrefix + "mid-1cone-chgstat_1_chgstat"),
               false),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.5_s),
@@ -49,12 +49,10 @@ Mid1ConeChgstat::Mid1ConeChgstat(SwerveDrive* drive,
 
 frc::Pose2d Mid1ConeChgstat::GetStartingPose(bool isBlue) {
   static auto blueStartingPose =
-      TrajectoryManager::GetInstance()
-          .GetTrajectory("blue-mid-1cone-chgstat_0_place6")
+      TrajectoryManager::GetTrajectory("blue-mid-1cone-chgstat_0_place6")
           .GetInitialPose();
   static auto redStartingPose =
-      TrajectoryManager::GetInstance()
-          .GetTrajectory("red-mid-1cone-chgstat_0_place6")
+      TrajectoryManager::GetTrajectory("red-mid-1cone-chgstat_0_place6")
           .GetInitialPose();
   if (isBlue)
     return blueStartingPose;

--- a/src/main/cpp/commands/autos/North2ConeChgstat.cpp
+++ b/src/main/cpp/commands/autos/North2ConeChgstat.cpp
@@ -22,7 +22,7 @@ North2ConeChgstat::North2ConeChgstat(SwerveDrive* drive,
           [superstructure]() { superstructure->PositionHigh(); }),
       frc2::WaitCommand(0.9_s),
       DriveTrajectory(drive,
-                      &TrajectoryManager::GetInstance().GetTrajectory(
+                      &TrajectoryManager::GetTrajectory(
                           allianceSidePrefix + "north-2cone-chgstat_0_place9")),
       frc2::InstantCommand(
           [superstructure]() { superstructure->SetExtenderPosition(false); }),
@@ -30,7 +30,7 @@ North2ConeChgstat::North2ConeChgstat(SwerveDrive* drive,
 
       frc2::ParallelDeadlineGroup(
           DriveTrajectory(
-              drive, &TrajectoryManager::GetInstance().GetTrajectory(
+              drive, &TrajectoryManager::GetTrajectory(
                          allianceSidePrefix + "north-2cone-chgstat_1_pick4")),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.25_s),
                                        frc2::InstantCommand([superstructure]() {
@@ -38,11 +38,11 @@ North2ConeChgstat::North2ConeChgstat(SwerveDrive* drive,
                                        }))),
 
       DriveTrajectory(drive,
-                      &TrajectoryManager::GetInstance().GetTrajectory(
+                      &TrajectoryManager::GetTrajectory(
                           allianceSidePrefix + "north-2cone-chgstat_2_align7")),
       frc2::ParallelDeadlineGroup(
           DriveTrajectory(
-              drive, &TrajectoryManager::GetInstance().GetTrajectory(
+              drive, &TrajectoryManager::GetTrajectory(
                          allianceSidePrefix + "north-2cone-chgstat_3_place7")),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.1_s),
                                        frc2::InstantCommand([superstructure]() {
@@ -54,7 +54,7 @@ North2ConeChgstat::North2ConeChgstat(SwerveDrive* drive,
       frc2::ParallelDeadlineGroup(
           DriveTrajectory(
               drive,
-              &TrajectoryManager::GetInstance().GetTrajectory(
+              &TrajectoryManager::GetTrajectory(
                   allianceSidePrefix + "north-2cone-chgstat_4_chgstat"),
               false),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.25_s),
@@ -70,12 +70,10 @@ North2ConeChgstat::North2ConeChgstat(SwerveDrive* drive,
 
 frc::Pose2d North2ConeChgstat::GetStartingPose(bool isBlue) {
   static auto blueStartingPose =
-      TrajectoryManager::GetInstance()
-          .GetTrajectory("blue-north-2cone-chgstat_0_place9")
+      TrajectoryManager::GetTrajectory("blue-north-2cone-chgstat_0_place9")
           .GetInitialPose();
   static auto redStartingPose =
-      TrajectoryManager::GetInstance()
-          .GetTrajectory("red-north-2cone-chgstat_0_place9")
+      TrajectoryManager::GetTrajectory("red-north-2cone-chgstat_0_place9")
           .GetInitialPose();
   if (isBlue)
     return blueStartingPose;

--- a/src/main/cpp/commands/autos/North3Cone.cpp
+++ b/src/main/cpp/commands/autos/North3Cone.cpp
@@ -39,9 +39,9 @@ North3Cone::North3Cone(SwerveDrive* drive, Superstructure* superstructure,
       DriveTrajectory(drive, &TrajectoryManager::GetTrajectory(
                                  allianceSidePrefix + "north-3cone_2_align7")),
       frc2::ParallelDeadlineGroup(
-          DriveTrajectory(drive,
-                          &TrajectoryManager::GetTrajectory(
-                              allianceSidePrefix + "north-3cone_3_place7")),
+          DriveTrajectory(
+              drive, &TrajectoryManager::GetTrajectory(allianceSidePrefix +
+                                                       "north-3cone_3_place7")),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.1_s),
                                        frc2::InstantCommand([superstructure]() {
                                          superstructure->PositionHigh();

--- a/src/main/cpp/commands/autos/North3Cone.cpp
+++ b/src/main/cpp/commands/autos/North3Cone.cpp
@@ -21,7 +21,7 @@ North3Cone::North3Cone(SwerveDrive* drive, Superstructure* superstructure,
           [superstructure]() { superstructure->PositionHigh(); }),
       frc2::WaitCommand(0.9_s),
       DriveTrajectory(drive,
-                      &TrajectoryManager::GetInstance().GetTrajectory(
+                      &TrajectoryManager::GetTrajectory(
                           allianceSidePrefix + "north-2cone-chgstat_0_place9")),
       frc2::InstantCommand(
           [superstructure]() { superstructure->SetExtenderPosition(false); }),
@@ -29,18 +29,18 @@ North3Cone::North3Cone(SwerveDrive* drive, Superstructure* superstructure,
 
       frc2::ParallelDeadlineGroup(
           DriveTrajectory(
-              drive, &TrajectoryManager::GetInstance().GetTrajectory(
+              drive, &TrajectoryManager::GetTrajectory(
                          allianceSidePrefix + "north-2cone-chgstat_1_pick4")),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.25_s),
                                        frc2::InstantCommand([superstructure]() {
                                          superstructure->IntakeCone();
                                        }))),
 
-      DriveTrajectory(drive, &TrajectoryManager::GetInstance().GetTrajectory(
+      DriveTrajectory(drive, &TrajectoryManager::GetTrajectory(
                                  allianceSidePrefix + "north-3cone_2_align7")),
       frc2::ParallelDeadlineGroup(
           DriveTrajectory(drive,
-                          &TrajectoryManager::GetInstance().GetTrajectory(
+                          &TrajectoryManager::GetTrajectory(
                               allianceSidePrefix + "north-3cone_3_place7")),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.1_s),
                                        frc2::InstantCommand([superstructure]() {
@@ -51,7 +51,7 @@ North3Cone::North3Cone(SwerveDrive* drive, Superstructure* superstructure,
 
       frc2::ParallelDeadlineGroup(
           DriveTrajectory(drive,
-                          &TrajectoryManager::GetInstance().GetTrajectory(
+                          &TrajectoryManager::GetTrajectory(
                               allianceSidePrefix + "north-3cone_4_pick3"),
                           false),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.25_s),
@@ -62,12 +62,10 @@ North3Cone::North3Cone(SwerveDrive* drive, Superstructure* superstructure,
 
 frc::Pose2d North3Cone::GetStartingPose(bool isBlue) {
   static auto blueStartingPose =
-      TrajectoryManager::GetInstance()
-          .GetTrajectory("blue-north-2cone-chgstat_0_place9")
+      TrajectoryManager::GetTrajectory("blue-north-2cone-chgstat_0_place9")
           .GetInitialPose();
   static auto redStartingPose =
-      TrajectoryManager::GetInstance()
-          .GetTrajectory("red-north-2cone-chgstat_0_place9")
+      TrajectoryManager::GetTrajectory("red-north-2cone-chgstat_0_place9")
           .GetInitialPose();
   if (isBlue)
     return blueStartingPose;

--- a/src/main/cpp/commands/autos/North3Cube.cpp
+++ b/src/main/cpp/commands/autos/North3Cube.cpp
@@ -25,7 +25,7 @@ North3Cube::North3Cube(SwerveDrive* drive, Superstructure* superstructure,
           SequentialCommandGroup(
               WaitCommand(0.0_s),
               DriveTrajectory(drive,
-                              &TrajectoryManager::GetInstance().GetTrajectory(
+                              &TrajectoryManager::GetTrajectory(
                                   allianceSidePrefix + "north-3cube_0_pick4"))),
           SequentialCommandGroup(InstantCommand([superstructure]() {
                                    superstructure->SetIntakeWheelSpeed(-0.5);
@@ -34,25 +34,25 @@ North3Cube::North3Cube(SwerveDrive* drive, Superstructure* superstructure,
                                  InstantCommand([superstructure]() {
                                    superstructure->IntakeCone();
                                  }))),
-      DriveTrajectory(drive, &TrajectoryManager::GetInstance().GetTrajectory(
+      DriveTrajectory(drive, &TrajectoryManager::GetTrajectory(
                                  allianceSidePrefix + "north-3cube_1_place8")),
       ParallelDeadlineGroup(
           SequentialCommandGroup(
               WaitCommand(0.1_s),
               DriveTrajectory(drive,
-                              &TrajectoryManager::GetInstance().GetTrajectory(
+                              &TrajectoryManager::GetTrajectory(
                                   allianceSidePrefix + "north-3cube_2_pick3"))),
           SequentialCommandGroup(
               InstantCommand([superstructure]() { superstructure->Outtake(); }),
               WaitCommand(1_s), InstantCommand([superstructure]() {
                 superstructure->IntakeCone();
               }))),
-      DriveTrajectory(drive, &TrajectoryManager::GetInstance().GetTrajectory(
+      DriveTrajectory(drive, &TrajectoryManager::GetTrajectory(
                                  allianceSidePrefix + "north-3cube_3_place7")),
       InstantCommand([superstructure]() { superstructure->Outtake(); }),
       ParallelDeadlineGroup(
           DriveTrajectory(drive,
-                          &TrajectoryManager::GetInstance().GetTrajectory(
+                          &TrajectoryManager::GetTrajectory(
                               allianceSidePrefix + "north-3cube_4_chgst")),
           SequentialCommandGroup(WaitCommand(0.75_s),
                                  InstantCommand([superstructure]() {
@@ -64,12 +64,11 @@ North3Cube::North3Cube(SwerveDrive* drive, Superstructure* superstructure,
 
 frc::Pose2d North3Cube::GetStartingPose(bool isBlue) {
   static auto blueStartingPose =
-      TrajectoryManager::GetInstance()
-          .GetTrajectory("blue-north-2cone-chgstat_0_place9")
+      TrajectoryManager::GetTrajectory(
+        "blue-north-2cone-chgstat_0_place9")
           .GetInitialPose();
   static auto redStartingPose =
-      TrajectoryManager::GetInstance()
-          .GetTrajectory("red-north-2cone-chgstat_0_place9")
+      TrajectoryManager::GetTrajectory("red-north-2cone-chgstat_0_place9")
           .GetInitialPose();
   if (isBlue)
     return blueStartingPose;

--- a/src/main/cpp/commands/autos/North3Cube.cpp
+++ b/src/main/cpp/commands/autos/North3Cube.cpp
@@ -51,9 +51,9 @@ North3Cube::North3Cube(SwerveDrive* drive, Superstructure* superstructure,
                                  allianceSidePrefix + "north-3cube_3_place7")),
       InstantCommand([superstructure]() { superstructure->Outtake(); }),
       ParallelDeadlineGroup(
-          DriveTrajectory(drive,
-                          &TrajectoryManager::GetTrajectory(
-                              allianceSidePrefix + "north-3cube_4_chgst")),
+          DriveTrajectory(
+              drive, &TrajectoryManager::GetTrajectory(allianceSidePrefix +
+                                                       "north-3cube_4_chgst")),
           SequentialCommandGroup(WaitCommand(0.75_s),
                                  InstantCommand([superstructure]() {
                                    superstructure->PositionLow();
@@ -64,8 +64,7 @@ North3Cube::North3Cube(SwerveDrive* drive, Superstructure* superstructure,
 
 frc::Pose2d North3Cube::GetStartingPose(bool isBlue) {
   static auto blueStartingPose =
-      TrajectoryManager::GetTrajectory(
-        "blue-north-2cone-chgstat_0_place9")
+      TrajectoryManager::GetTrajectory("blue-north-2cone-chgstat_0_place9")
           .GetInitialPose();
   static auto redStartingPose =
       TrajectoryManager::GetTrajectory("red-north-2cone-chgstat_0_place9")

--- a/src/main/cpp/commands/autos/South2Cone.cpp
+++ b/src/main/cpp/commands/autos/South2Cone.cpp
@@ -28,17 +28,17 @@ South2Cone::South2Cone(SwerveDrive* drive, Superstructure* superstructure,
       frc2::WaitCommand(0.1_s),
 
       frc2::ParallelDeadlineGroup(
-          DriveTrajectory(drive,
-                          &TrajectoryManager::GetTrajectory(
-                              allianceSidePrefix + "south-2cone_1_pick1")),
+          DriveTrajectory(
+              drive, &TrajectoryManager::GetTrajectory(allianceSidePrefix +
+                                                       "south-2cone_1_pick1")),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.25_s),
                                        frc2::InstantCommand([superstructure]() {
                                          superstructure->IntakeCone();
                                        }))),
       frc2::ParallelDeadlineGroup(
-          DriveTrajectory(drive,
-                          &TrajectoryManager::GetTrajectory(
-                              allianceSidePrefix + "south-2cone_2_place3")),
+          DriveTrajectory(
+              drive, &TrajectoryManager::GetTrajectory(allianceSidePrefix +
+                                                       "south-2cone_2_place3")),
           frc2::SequentialCommandGroup(frc2::WaitCommand(4.0_s),
                                        frc2::InstantCommand([superstructure]() {
                                          superstructure->PositionHigh();
@@ -63,10 +63,12 @@ South2Cone::South2Cone(SwerveDrive* drive, Superstructure* superstructure,
 }
 
 frc::Pose2d South2Cone::GetStartingPose(bool isBlue) {
-  static auto blueStartingPose = TrajectoryManager::GetTrajectory("blue-south-2cone_0_place1")
-                                     .GetInitialPose();
-  static auto redStartingPose = TrajectoryManager::GetTrajectory("red-south-2cone_0_place1")
-                                    .GetInitialPose();
+  static auto blueStartingPose =
+      TrajectoryManager::GetTrajectory("blue-south-2cone_0_place1")
+          .GetInitialPose();
+  static auto redStartingPose =
+      TrajectoryManager::GetTrajectory("red-south-2cone_0_place1")
+          .GetInitialPose();
   if (isBlue)
     return blueStartingPose;
   else

--- a/src/main/cpp/commands/autos/South2Cone.cpp
+++ b/src/main/cpp/commands/autos/South2Cone.cpp
@@ -21,7 +21,7 @@ South2Cone::South2Cone(SwerveDrive* drive, Superstructure* superstructure,
       frc2::InstantCommand(
           [superstructure]() { superstructure->PositionHigh(); }),
       frc2::WaitCommand(0.9_s),
-      DriveTrajectory(drive, &TrajectoryManager::GetInstance().GetTrajectory(
+      DriveTrajectory(drive, &TrajectoryManager::GetTrajectory(
                                  allianceSidePrefix + "south-2cone_0_place1")),
       frc2::InstantCommand(
           [superstructure]() { superstructure->SetExtenderPosition(false); }),
@@ -29,7 +29,7 @@ South2Cone::South2Cone(SwerveDrive* drive, Superstructure* superstructure,
 
       frc2::ParallelDeadlineGroup(
           DriveTrajectory(drive,
-                          &TrajectoryManager::GetInstance().GetTrajectory(
+                          &TrajectoryManager::GetTrajectory(
                               allianceSidePrefix + "south-2cone_1_pick1")),
           frc2::SequentialCommandGroup(frc2::WaitCommand(0.25_s),
                                        frc2::InstantCommand([superstructure]() {
@@ -37,7 +37,7 @@ South2Cone::South2Cone(SwerveDrive* drive, Superstructure* superstructure,
                                        }))),
       frc2::ParallelDeadlineGroup(
           DriveTrajectory(drive,
-                          &TrajectoryManager::GetInstance().GetTrajectory(
+                          &TrajectoryManager::GetTrajectory(
                               allianceSidePrefix + "south-2cone_2_place3")),
           frc2::SequentialCommandGroup(frc2::WaitCommand(4.0_s),
                                        frc2::InstantCommand([superstructure]() {
@@ -48,7 +48,7 @@ South2Cone::South2Cone(SwerveDrive* drive, Superstructure* superstructure,
 
       // frc2::ParallelDeadlineGroup(
       //     DriveTrajectory(drive,
-      //                     &TrajectoryManager::GetInstance().GetTrajectory(allianceSidePrefix
+      //                     &TrajectoryManager::GetTrajectory(allianceSidePrefix
       //                     + "north-2cone-chgstat_4_chgstat"), false),
       //     frc2::SequentialCommandGroup(frc2::WaitCommand(0.25_s),
       //                                  frc2::InstantCommand([superstructure]()
@@ -63,11 +63,9 @@ South2Cone::South2Cone(SwerveDrive* drive, Superstructure* superstructure,
 }
 
 frc::Pose2d South2Cone::GetStartingPose(bool isBlue) {
-  static auto blueStartingPose = TrajectoryManager::GetInstance()
-                                     .GetTrajectory("blue-south-2cone_0_place1")
+  static auto blueStartingPose = TrajectoryManager::GetTrajectory("blue-south-2cone_0_place1")
                                      .GetInitialPose();
-  static auto redStartingPose = TrajectoryManager::GetInstance()
-                                    .GetTrajectory("red-south-2cone_0_place1")
+  static auto redStartingPose = TrajectoryManager::GetTrajectory("red-south-2cone_0_place1")
                                     .GetInitialPose();
   if (isBlue)
     return blueStartingPose;

--- a/src/main/cpp/util/TrajectoryManager.cpp
+++ b/src/main/cpp/util/TrajectoryManager.cpp
@@ -20,13 +20,9 @@ using std::filesystem::directory_iterator;
 using std::filesystem::path;
 using wpi::json;
 
-TrajectoryManager& TrajectoryManager::GetInstance() {
-  return s_instance;
-}
-
 const Trajectory& TrajectoryManager::GetTrajectory(
-    const std::string& name) const {
-  return m_trajectories.at(name);
+    const std::string& name) {
+  return s_instance.m_trajectories.at(name);
 }
 
 std::map<std::string, Trajectory> TrajectoryManager::LoadTrajectories() {

--- a/src/main/cpp/util/TrajectoryManager.cpp
+++ b/src/main/cpp/util/TrajectoryManager.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <map>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -28,29 +29,32 @@ const Trajectory& TrajectoryManager::GetTrajectory(
   return m_trajectories.at(name);
 }
 
-void TrajectoryManager::LoadTrajectories() {
+std::map<std::string, Trajectory> TrajectoryManager::LoadTrajectories() {
+  std::map<std::string, Trajectory> trajectories;
   path trajDir =
       path(frc::filesystem::GetDeployDirectory()) / path("trajectories");
   for (const auto& file : directory_iterator(trajDir)) {
-    std::string filepath = file.path().string();
-    std::string filename = filepath.substr(filepath.find_last_of('/') + 1);
+    auto filename = file.path().filename().string();
     if (filename.ends_with(".json")) {
       std::string trajname = filename.substr(0, filename.length() - 5);
-      m_trajectories.insert({trajname, LoadFile(file.path())});
+      trajectories.insert({trajname, LoadFile(file.path())});
     }
   }
+  return trajectories;
 }
 
 Trajectory TrajectoryManager::LoadFile(const path& trajPath) {
   std::ifstream fileStream(trajPath);
-  std::stringstream buffer;
-  buffer << fileStream.rdbuf();
-  auto parsed = json::parse(buffer.str());
-  return json(parsed);
+  if (!fileStream.fail()) {
+    std::stringstream buffer;
+    buffer << fileStream.rdbuf();
+    auto parsed = json::parse(buffer.str());
+    return json(parsed);
+  } else {
+    throw std::runtime_error("Error loading trajectory file.");
+  }
 }
 
-TrajectoryManager::TrajectoryManager() {
-  LoadTrajectories();
-}
+TrajectoryManager::TrajectoryManager() : m_trajectories{LoadTrajectories()} {}
 
 TrajectoryManager TrajectoryManager::s_instance{};

--- a/src/main/cpp/util/TrajectoryManager.cpp
+++ b/src/main/cpp/util/TrajectoryManager.cpp
@@ -20,8 +20,7 @@ using std::filesystem::directory_iterator;
 using std::filesystem::path;
 using wpi::json;
 
-const Trajectory& TrajectoryManager::GetTrajectory(
-    const std::string& name) {
+const Trajectory& TrajectoryManager::GetTrajectory(const std::string& name) {
   return s_instance.m_trajectories.at(name);
 }
 

--- a/src/main/include/util/TrajectoryManager.hpp
+++ b/src/main/include/util/TrajectoryManager.hpp
@@ -14,16 +14,14 @@
 
 class TrajectoryManager {
  public:
-  static TrajectoryManager& GetInstance();
-
-  const Trajectory& GetTrajectory(const std::string& name) const;
+  static const Trajectory& GetTrajectory(const std::string& name);
 
  private:
   std::map<std::string, Trajectory> LoadTrajectories();
 
   static Trajectory LoadFile(const std::filesystem::path& trajPath);
 
-  const std::map<std::string, Trajectory> m_trajectories;
+  std::map<std::string, Trajectory> m_trajectories;
 
   TrajectoryManager();
 

--- a/src/main/include/util/TrajectoryManager.hpp
+++ b/src/main/include/util/TrajectoryManager.hpp
@@ -19,11 +19,11 @@ class TrajectoryManager {
   const Trajectory& GetTrajectory(const std::string& name) const;
 
  private:
-  void LoadTrajectories();
+  std::map<std::string, Trajectory> LoadTrajectories();
 
   static Trajectory LoadFile(const std::filesystem::path& trajPath);
 
-  std::map<std::string, Trajectory> m_trajectories;
+  const std::map<std::string, Trajectory> m_trajectories;
 
   TrajectoryManager();
 


### PR DESCRIPTION
- This avoids the problem of dangling references to objects in the map which have been deallocated after new items are added to the map